### PR TITLE
ci: add musllinux_1_1 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ jobs:
           - runner: ubuntu-latest
             target: x86
           - runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - runner: ubuntu-latest
+            target: i686-unknown-linux-musl
+          - runner: ubuntu-latest
             target: aarch64
           - runner: ubuntu-latest
             target: armv7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
   linux:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - runner: ubuntu-latest
@@ -26,8 +27,10 @@ jobs:
             target: x86
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-musl
+            manylinux: musllinux_1_1
           - runner: ubuntu-latest
             target: i686-unknown-linux-musl
+            manylinux: musllinux_1_1
           - runner: ubuntu-latest
             target: aarch64
           - runner: ubuntu-latest
@@ -47,7 +50,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: 'true'
-          manylinux: auto
+          manylinux: ${{ matrix.platform.manylinux || 'auto' }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyproject-fmt-rust"
-version = "1.0.1"
+version = "1.0.2"
 description = "Format pyproject.toml files"
 repository = "https://github.com/tox-dev/pyproject-fmt"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ requires = [
 
 [project]
 name = "pyproject-fmt-rust"
-version = "1.0.1"
 description = "Format your pyproject.toml file"
 readme = "README.md"
 keywords = [


### PR DESCRIPTION
This adds musllinux, and since I figured out how to target 1_1, went ahead and targeted it here.

By the way, the i686 manglinux wheel is getting tagged as manylinux1, while all the others are getting the (correct) manylinux2014 tags. Not sure why it would be different.