### PR TITLE
ci: Add pypy on macOS & linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,6 @@ jobs:
         platform:
           - runner: windows-latest
             target: x64
-            interpreter: "3.8 pypy3.9 pypy3.10"
           - runner: windows-latest
             target: x86
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,6 @@ jobs:
             target: ppc64le
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -71,8 +68,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        if: matrix.platform.target == 'x64'
         with:
-          python-version: '3.12'
+          python-version: |
+            pypy3.8
+            pypy3.9
+            pypy3.10
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         platform:
           - runner: ubuntu-latest
             target: x86_64
+            interpreter: "3.8 pypy3.8 pypy3.9 pypy3.10"
           - runner: ubuntu-latest
             target: x86
           - runner: ubuntu-latest
@@ -48,7 +49,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist
+          args: --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.8' }}
           sccache: 'true'
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
       - name: Upload wheels
@@ -64,6 +65,7 @@ jobs:
         platform:
           - runner: windows-latest
             target: x64
+            interpreter: "3.8 pypy3.8 pypy3.9 pypy3.10"
           - runner: windows-latest
             target: x86
     steps:
@@ -76,7 +78,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist
+          args: --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.8' }}
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -102,7 +104,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist
+          args: --release --out dist --interpreter "3.8 pypy3.8 pypy3.9 pypy3.10"
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,19 +62,11 @@ jobs:
         platform:
           - runner: windows-latest
             target: x64
-            interpreter: "3.8 pypy3.8 pypy3.9 pypy3.10"
+            interpreter: "3.8 pypy3.9 pypy3.10"
           - runner: windows-latest
             target: x86
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        if: matrix.platform.target == 'x64'
-        with:
-          python-version: |
-            pypy3.8
-            pypy3.9
-            pypy3.10
-          architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -98,9 +90,6 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
Windows claims it can't find an interpreter. 64-bit Windows support from pypy is somewhat recent (year or two), maybe a maturin or maturin-action bug?