### PR TITLE
Fix subsubtable order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +268,16 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -520,8 +536,9 @@ dependencies = [
 
 [[package]]
 name = "pyproject-fmt-rust"
-version = "1.0.1"
+version = "1.0.4"
 dependencies = [
+ "indexmap",
  "indoc",
  "lexical-sort",
  "pep508_rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,12 +103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,16 +262,6 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
-dependencies = [
- "equivalent",
- "hashbrown",
 ]
 
 [[package]]
@@ -538,7 +522,6 @@ dependencies = [
 name = "pyproject-fmt-rust"
 version = "1.0.4"
 dependencies = [
- "indexmap",
  "indoc",
  "lexical-sort",
  "pep508_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ pyo3 = { version = "0.21.2", features = ["abi3-py38"] } # integration with Pytho
 pep508_rs = { version = "0.5.0" }
 lexical-sort = { version = "0.3.1" }
 regex = { version = "1.10.4" }
-indexmap = "2.2.6"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ pyo3 = { version = "0.21.2", features = ["abi3-py38"] } # integration with Pytho
 pep508_rs = { version = "0.5.0" }
 lexical-sort = { version = "0.3.1" }
 regex = { version = "1.10.4" }
+indexmap = "2.2.6"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/rust/src/global.rs
+++ b/rust/src/global.rs
@@ -101,6 +101,12 @@ mod tests {
     mr="vr"
     [demo]
     ed = "ed"
+    [tool.coverage.report]
+    cd="de"
+    [tool.coverage.paths]
+    ab="bc"
+    [tool.coverage.run]
+    ef="fg"
     [tool.pytest]
     mk="mv"
     "#},
@@ -128,6 +134,13 @@ mod tests {
 
     [tool.pytest]
     mk = "mv"
+
+    [tool.coverage.paths]
+    ab = "bc"
+    [tool.coverage.report]
+    cd = "de"
+    [tool.coverage.run]
+    ef = "fg"
 
     [tool.mypy]
     mk = "mv"

--- a/rust/src/global.rs
+++ b/rust/src/global.rs
@@ -103,6 +103,8 @@ mod tests {
     ed = "ed"
     [tool.coverage.report]
     cd="de"
+    [tool.coverage]
+    aa = "bb"
     [tool.coverage.paths]
     ab="bc"
     [tool.coverage.run]
@@ -135,6 +137,8 @@ mod tests {
     [tool.pytest]
     mk = "mv"
 
+    [tool.coverage]
+    aa = "bb"
     [tool.coverage.report]
     cd = "de"
     [tool.coverage.paths]

--- a/rust/src/global.rs
+++ b/rust/src/global.rs
@@ -135,10 +135,10 @@ mod tests {
     [tool.pytest]
     mk = "mv"
 
-    [tool.coverage.paths]
-    ab = "bc"
     [tool.coverage.report]
     cd = "de"
+    [tool.coverage.paths]
+    ab = "bc"
     [tool.coverage.run]
     ef = "fg"
 

--- a/rust/src/helpers/table.rs
+++ b/rust/src/helpers/table.rs
@@ -87,22 +87,21 @@ fn calculate_order(header_to_pos: &HashMap<String, usize>, ordering: &[&str]) ->
         .map(|(k, v)| (v, k * 2))
         .collect::<HashMap<&&str, usize>>();
 
-    // order headers by pos
     let mut header_pos: Vec<(String, usize)> = header_to_pos.clone().into_iter().collect();
-    header_pos.sort_by_key(|&(_, v)| v);
-    let mut order: Vec<String> = header_pos.into_iter().map(|(k, _)| k).collect();
 
-    order.sort_by_cached_key(|k| -> usize {
+    header_pos.sort_by_cached_key(|(k, file_pos)| -> (usize, usize) {
         let key = get_key(k);
         let pos = key_to_pos.get(&key.as_str());
-        if pos.is_some() {
-            let offset = usize::from(key != *k);
-            pos.unwrap() + offset
-        } else {
-            max_ordering + header_to_pos[k]
+
+        match pos {
+            Some(&pos) => {
+                let offset = usize::from(key != *k);
+                (pos + offset, *file_pos)
+            }
+            None => (max_ordering + *file_pos, 0),
         }
     });
-    order
+    header_pos.into_iter().map(|(k, _)| k).collect()
 }
 
 fn get_key(k: &str) -> String {

--- a/rust/src/helpers/table.rs
+++ b/rust/src/helpers/table.rs
@@ -1,5 +1,5 @@
 use std::cell::{RefCell, RefMut};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::iter::zip;
 
 use taplo::syntax::SyntaxKind::{TABLE_ARRAY_HEADER, TABLE_HEADER};
@@ -11,7 +11,8 @@ use crate::helpers::string::load_text;
 
 #[derive(Debug)]
 pub struct Tables {
-    pub header_to_pos: HashMap<String, usize>,
+    // headers would be enumerated in sorted order
+    pub header_to_pos: BTreeMap<String, usize>,
     pub table_set: Vec<RefCell<Vec<SyntaxElement>>>,
 }
 
@@ -25,7 +26,7 @@ impl Tables {
     }
 
     pub fn from_ast(root_ast: &SyntaxNode) -> Self {
-        let mut header_to_pos = HashMap::<String, usize>::new();
+        let mut header_to_pos = BTreeMap::<String, usize>::new();
         let mut table_set = Vec::<RefCell<Vec<SyntaxElement>>>::new();
         let entry_set = RefCell::new(Vec::<SyntaxElement>::new());
         let mut add_to_table_set = || {
@@ -79,7 +80,7 @@ impl Tables {
     }
 }
 
-fn calculate_order(header_to_pos: &HashMap<String, usize>, ordering: &[&str]) -> Vec<String> {
+fn calculate_order(header_to_pos: &BTreeMap<String, usize>, ordering: &[&str]) -> Vec<String> {
     let max_ordering = ordering.len() * 2;
     let key_to_pos = ordering
         .iter()

--- a/rust/src/helpers/table.rs
+++ b/rust/src/helpers/table.rs
@@ -93,13 +93,15 @@ fn calculate_order(header_to_pos: &HashMap<String, usize>, ordering: &[&str]) ->
         let key = get_key(k);
         let pos = key_to_pos.get(&key.as_str());
 
-        match pos {
-            Some(&pos) => {
+        (
+            if let Some(&pos) = pos {
                 let offset = usize::from(key != *k);
-                (pos + offset, *file_pos)
-            }
-            None => (max_ordering + *file_pos, 0),
-        }
+                pos + offset
+            } else {
+                max_ordering
+            },
+            *file_pos,
+        )
     });
     header_pos.into_iter().map(|(k, _)| k).collect()
 }

--- a/rust/src/helpers/table.rs
+++ b/rust/src/helpers/table.rs
@@ -1,7 +1,8 @@
 use std::cell::{RefCell, RefMut};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::iter::zip;
 
+use indexmap::IndexMap;
 use taplo::syntax::SyntaxKind::{TABLE_ARRAY_HEADER, TABLE_HEADER};
 use taplo::syntax::{SyntaxElement, SyntaxKind, SyntaxNode};
 use taplo::HashSet;
@@ -11,8 +12,8 @@ use crate::helpers::string::load_text;
 
 #[derive(Debug)]
 pub struct Tables {
-    // headers would be enumerated in sorted order
-    pub header_to_pos: BTreeMap<String, usize>,
+    // headers would be enumerated in insertion order
+    pub header_to_pos: IndexMap<String, usize>,
     pub table_set: Vec<RefCell<Vec<SyntaxElement>>>,
 }
 
@@ -26,7 +27,7 @@ impl Tables {
     }
 
     pub fn from_ast(root_ast: &SyntaxNode) -> Self {
-        let mut header_to_pos = BTreeMap::<String, usize>::new();
+        let mut header_to_pos = IndexMap::<String, usize>::new();
         let mut table_set = Vec::<RefCell<Vec<SyntaxElement>>>::new();
         let entry_set = RefCell::new(Vec::<SyntaxElement>::new());
         let mut add_to_table_set = || {
@@ -80,7 +81,7 @@ impl Tables {
     }
 }
 
-fn calculate_order(header_to_pos: &BTreeMap<String, usize>, ordering: &[&str]) -> Vec<String> {
+fn calculate_order(header_to_pos: &IndexMap<String, usize>, ordering: &[&str]) -> Vec<String> {
     let max_ordering = ordering.len() * 2;
     let key_to_pos = ordering
         .iter()

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -182,6 +182,8 @@ mod tests {
     [project]
     [tool.coverage.report]
     a = 2
+    [tool.coverage]
+    a = 0
     [tool.coverage.paths]
     a = 1
     [tool.coverage.run]
@@ -193,6 +195,8 @@ mod tests {
       "Programming Language :: Python :: 3 :: Only",
       "Programming Language :: Python :: 3.8",
     ]
+    [tool.coverage]
+    a = 0
     [tool.coverage.report]
     a = 2
     [tool.coverage.paths]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -177,6 +177,33 @@ mod tests {
         true,
         (3, 8)
     )]
+    #[case::subsubtable(
+        indoc ! {r#"
+    [project]
+    [tool.coverage.paths]
+    a = 1
+    [tool.coverage.report]
+    a = 2
+    [tool.coverage.run]
+    a = 3
+    "#},
+        indoc ! {r#"
+    [project]
+    classifiers = [
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.8",
+    ]
+    [tool.coverage.paths]
+    a = 1
+    [tool.coverage.report]
+    a = 2
+    [tool.coverage.run]
+    a = 3
+    "#},
+        2,
+        true,
+        (3, 8)
+    )]
     fn test_format_toml(
         #[case] start: &str,
         #[case] expected: &str,

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -180,10 +180,10 @@ mod tests {
     #[case::subsubtable(
         indoc ! {r#"
     [project]
-    [tool.coverage.paths]
-    a = 1
     [tool.coverage.report]
     a = 2
+    [tool.coverage.paths]
+    a = 1
     [tool.coverage.run]
     a = 3
     "#},
@@ -193,10 +193,10 @@ mod tests {
       "Programming Language :: Python :: 3 :: Only",
       "Programming Language :: Python :: 3.8",
     ]
-    [tool.coverage.paths]
-    a = 1
     [tool.coverage.report]
     a = 2
+    [tool.coverage.paths]
+    a = 1
     [tool.coverage.run]
     a = 3
     "#},


### PR DESCRIPTION
This is to fix sort order among subtables, e.g. "tool.coverage.paths", "tool.coverage.report" and "tool.coverage.run".

Pls refer to the issue: https://github.com/tox-dev/pyproject-fmt-rust/issues/8 for details.