### PR TITLE
Fix typo, scritps -> scripts

### DIFF
--- a/rust/src/project.rs
+++ b/rust/src/project.rs
@@ -773,7 +773,7 @@ mod tests {
         true,
         (3, 8),
     )]
-    #[case::project_scritps_collapse(
+    #[case::project_scripts_collapse(
         indoc ! {r#"
     [project.scripts]
     c = 'd'


### PR DESCRIPTION
Found via `typos --hidden --format brief`