### PR TITLE
tests: show issue 27

### DIFF
--- a/rust/src/build_system.rs
+++ b/rust/src/build_system.rs
@@ -110,6 +110,25 @@ mod tests {
     "#},
         false
     )]
+    #[case::reorder(
+        indoc ! {r#"
+    [build-system]
+    requires = [
+      "hatchling",
+    ]
+    build-backend = "hatchling.build"
+
+    "#},
+        indoc ! {r#"
+    [build-system]
+    build-backend = "hatchling.build"
+    requires = [
+      "hatchling",
+    ]
+
+    "#},
+        false
+    )]
     fn test_format_build_systems(#[case] start: &str, #[case] expected: &str, #[case] keep_full_version: bool) {
         assert_eq!(evaluate(start, keep_full_version), expected);
     }

--- a/rust/src/helpers/table.rs
+++ b/rust/src/helpers/table.rs
@@ -316,3 +316,24 @@ pub fn collapse_sub_tables(tables: &mut Tables, name: &str) {
         sub.clear();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use taplo::parser::parse;
+
+    #[test]
+    fn test_reorder() {
+        let root_ast = parse("[A]\nb = 1\na = 1\n\n[B]\nb = 2")
+            .into_syntax()
+            .clone_for_update();
+        let mut tables = Tables::from_ast(&root_ast);
+        {
+            let table = &mut tables.get("A").unwrap().first().unwrap().borrow_mut();
+            reorder_table_keys(table, &["", "a", "b"]);
+        }
+        tables.reorder(&root_ast, &["B", "A"]);
+        assert_eq!(root_ast.to_string(), "[B]\nb = 2\n\n[A]\na = 1\n\nb = 1\n\n");
+    }
+}

--- a/rust/src/helpers/table.rs
+++ b/rust/src/helpers/table.rs
@@ -328,7 +328,7 @@ mod tests {
         let root_ast = parse("[A]\nb = 1\na = 1\n\n[B]\nb = 2")
             .into_syntax()
             .clone_for_update();
-        let mut tables = Tables::from_ast(&root_ast);
+        let tables = Tables::from_ast(&root_ast);
         {
             let table = &mut tables.get("A").unwrap().first().unwrap().borrow_mut();
             reorder_table_keys(table, &["", "a", "b"]);

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -272,6 +272,29 @@ mod tests {
         true,
         (3, 8)
     )]
+    #[case::space_issue_27(
+        indoc ! {r#"
+    [build-system]
+    requires = [
+      "hatchling",
+    ]
+    build-backend = "hatchling.build"
+
+    [project]
+    "#},
+        indoc ! {r#"
+    [build-system]
+    build-backend = "hatchling.build"
+    requires = [
+      "hatchling",
+    ]
+
+    [project]
+    "#},
+        2,
+        true,
+        (3, 8)
+    )]
     fn test_format_toml(
         #[case] start: &str,
         #[case] expected: &str,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -66,6 +66,53 @@ from pyproject_fmt_rust import Settings, format_toml
             """,
             id="collapsed",
         ),
+        pytest.param(
+            """
+            [build-system]
+            requires = [
+                "hatchling",
+            ]
+            build-backend = "hatchling.build"
+
+            [project]
+            keywords = [
+              "A",
+            ]
+            classifiers = [
+              "Programming Language :: Python :: 3 :: Only",
+            ]
+            dynamic = [
+              "B",
+            ]
+            dependencies = [
+              "requests>=2.0",
+            ]
+            """,
+            """\
+            [build-system]
+            build-backend = "hatchling.build"
+            requires = [
+                "hatchling",
+            ]
+
+            [project]
+            keywords = [
+                "A",
+            ]
+            classifiers = [
+                "Programming Language :: Python :: 3 :: Only",
+                "Programming Language :: Python :: 3.7",
+                "Programming Language :: Python :: 3.8",
+            ]
+            dynamic = [
+                "B",
+            ]
+            dependencies = [
+                "requests>=2.0",
+            ]
+            """,
+            id="multi",
+        ),
     ],
 )
 def test_format_toml(start: str, expected: str) -> None:


### PR DESCRIPTION
Close tox-dev/toml-fmt#7. Starting with tests. ~~Not sure why only the Python one fails!~~ Ah, `[project]` also has to be present.

The problem is that trailing whitespace is attached to the item. So `a\n\n` is moved around as a unit. I think it's tricky to solve nicely for all situations.

I think what makes sense is to preserve space around headings. So the only part given to the reorder is the chunk that starts with a non-space and ends with an entry.

(I'm referring to the part before running the normal run that limits spaces to one line, etc)