### PR TITLE
Don't sort and de-duplicate based on canonical name only

### DIFF
--- a/rust/src/project.rs
+++ b/rust/src/project.rs
@@ -55,7 +55,7 @@ pub fn fix(
         }
         "dependencies" | "optional-dependencies" => {
             transform(entry, &|s| format_requirement(s, keep_full_version));
-            sort(entry, |e| get_canonic_requirement_name(e).to_lowercase());
+            sort(entry, |e| get_canonic_requirement_name(e).to_lowercase() + " " + &format_requirement(e, keep_full_version));
         }
         "dynamic" | "keywords" => {
             transform(entry, &|s| String::from(s));

--- a/rust/src/project.rs
+++ b/rust/src/project.rs
@@ -716,6 +716,31 @@ mod tests {
         true,
         (3, 12),
     )]
+    #[case::project_platform_dependencies(
+        indoc ! {r#"
+    [project]
+    dependencies = [
+        'pyperclip; platform_system == "Darwin"',
+        'pyperclip; platform_system == "Windows"',
+        "appdirs"
+    ]
+    requires-python = "==3.12"
+    "#},
+        indoc ! {r#"
+    [project]
+    requires-python = "==3.12"
+    classifiers = [
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.12",
+    ]
+    dependencies = [
+      "appdirs",
+      "pyperclip; platform_system=='Windows'",
+    ]
+    "#},
+        true,
+        (3, 12),
+    )]
     #[case::project_opt_inline_dependencies(
         indoc ! {r#"
     [project]

--- a/rust/src/project.rs
+++ b/rust/src/project.rs
@@ -735,6 +735,7 @@ mod tests {
     ]
     dependencies = [
       "appdirs",
+      "pyperclip; platform_system=='Darwin'",
       "pyperclip; platform_system=='Windows'",
     ]
     "#},


### PR DESCRIPTION
Fixes https://github.com/tox-dev/pyproject-fmt/issues/231.

When sorting the list of dependencies, it used to only use the canonical name (for example, just `pyperclip`). This also include the formatted name in the sort operation so we also take the extra info like `platform_system=='Darwin'` into consideration.