### PR TITLE
ci: drop unused bits

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,12 +35,8 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install tox
         run: uv tool install --python-preference only-managed --python 3.13 tox --with tox-uv
-      - name: Install Python
-        if: startsWith(matrix.env, '3.') && matrix.env != '3.13'
-        run: uv python install --python-preference only-managed ${{ matrix.env }}
       - uses: moonrepo/setup-rust@v1
         with:
           cache-base: main

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,6 +37,9 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: Install tox
         run: uv tool install --python-preference only-managed --python 3.13 tox --with tox-uv
+      - name: Install Python
+        if: matrix.py != '3.13'
+        run: uv python install --python-preference only-managed ${{ matrix.env }}
       - uses: moonrepo/setup-rust@v1
         with:
           cache-base: main


### PR DESCRIPTION
`github-token` is now the default and there is no `matrix.env` so that step never ran.